### PR TITLE
[Fix/#41] UseCase 수정, 16KB 페이지 대응, 마이 뷰모델 로직 수정

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/kus/kustaurant/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/kus/kustaurant/App.kt
@@ -1,7 +1,7 @@
 package com.kus.kustaurant
 
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.kus.designsystem.component.LoginRequiredOverlay
+import com.kus.designsystem.component.LoginRequiredDialog
 import com.kus.designsystem.component.snackbar.KusSnackBarOverlay
 import com.kus.designsystem.component.snackbar.LocalSnackBarBottomPadding
 import com.kus.designsystem.theme.KusTheme
@@ -135,7 +135,7 @@ fun SetNavigation() {
             )
 
             if (showRequireLoginPopup) {
-                LoginRequiredOverlay(
+                LoginRequiredDialog(
                     onLoginButtonClick = {
                         showRequireLoginPopup = false
                         navController.navigate(Login) {

--- a/composeApp/src/commonMain/kotlin/com/kus/kustaurant/di/initKoin.kt
+++ b/composeApp/src/commonMain/kotlin/com/kus/kustaurant/di/initKoin.kt
@@ -3,7 +3,7 @@ package com.kus.kustaurant.di
 import com.kus.core.config.di.configModule
 import com.kus.data.auth.di.authDataModule
 import com.kus.data.community.di.communityDataModule
-import com.kus.data.draw.di.DrawDataModule
+import com.kus.data.draw.di.drawDataModule
 import com.kus.data.firstLaunch.di.firstLaunchDataModule
 import com.kus.data.my.di.myDataModule
 import com.kus.data.network.di.networkModule
@@ -72,7 +72,7 @@ fun initKoin(
             detailDataModule,
             evaluateDataModule,
             myDataModule,
-            DrawDataModule,
+            drawDataModule,
 
             // feature
             splashFeatureModule,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ okio = "3.9.0"
 multiplatform-settings = "1.1.1"
 kotlinx-io = "0.8.2"
 compottie = "2.0.2"
+cameraX = "1.5.3"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -101,6 +102,10 @@ kamel-image-default = { module = "media.kamel:kamel-image-default", version.ref 
 peekaboo-ui = { module = "io.github.onseok:peekaboo-ui", version.ref = "peekaboo" }
 peekaboo-image-picker = { module = "io.github.onseok:peekaboo-image-picker", version.ref = "peekaboo" }
 
+androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "cameraX" }
+androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "cameraX" }
+androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "cameraX" }
+
 naver-maps = { group = "com.naver.maps", name = "map-sdk", version.ref = "naverMaps" }
 naver-oauth = { group = "com.navercorp.nid", name = "oauth", version.ref = "naverOauth" }
 
@@ -132,4 +137,10 @@ ktor = [
     "ktor-client-auth",
     "ktor-client-logging",
     "ktor-serialization-kotlinx-json",
+]
+
+androidxCamera = [
+    "androidx-camera-core",
+    "androidx-camera-camera2",
+    "androidx-camera-lifecycle",
 ]

--- a/shared/core/designSystem/src/commonMain/kotlin/com/kus/designsystem/component/LoginRequiredDialog.kt
+++ b/shared/core/designSystem/src/commonMain/kotlin/com/kus/designsystem/component/LoginRequiredDialog.kt
@@ -1,15 +1,14 @@
 package com.kus.designsystem.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
 import com.kus.designsystem.theme.KusTheme
 import com.kus.designsystem.util.noRippleClickable
 
@@ -28,64 +28,64 @@ import com.kus.designsystem.util.noRippleClickable
  * @param onDismissRequest 취소 버튼 및 외부 영역 터치 시 호출되는 콜백
  */
 @Composable
-fun LoginRequiredOverlay(
+fun LoginRequiredDialog(
     modifier: Modifier = Modifier,
     onLoginButtonClick: () -> Unit,
     onDismissRequest: () -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(KusTheme.colors.c_000000.copy(alpha = 0.5f))
-            .noRippleClickable(onDismissRequest),
-        contentAlignment = Alignment.Center,
+    Dialog(
+        onDismissRequest = onDismissRequest,
     ) {
-        Box(
-            modifier = modifier
-                .width(300.dp)
-                .background(KusTheme.colors.c_FFFFFF, RoundedCornerShape(16.dp))
-                .noRippleClickable {} // 팝업 내부 클릭 시 dismiss 방지
-                .padding(20.dp)
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            tonalElevation = 8.dp,
+            color = KusTheme.colors.c_FFFFFF,
         ) {
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalAlignment = Alignment.CenterHorizontally,
+            Box(
+                modifier = modifier
+                    .width(300.dp)
+                    .padding(20.dp),
             ) {
-                Text(
-                    text = "안내",
-                    style = KusTheme.typography.type16b,
-                    color = KusTheme.colors.c_AAAAAA,
-                )
-
-                Spacer(Modifier.height(8.dp))
-
-                Text(
-                    text = "현재 서비스는 로그인 후\n이용할 수 있습니다",
-                    style = KusTheme.typography.type16m,
-                    textAlign = TextAlign.Center,
-                )
-
-                Spacer(Modifier.height(18.dp))
-
-                KusButton(
-                    enabled = true,
-                    buttonName = "로그인 하러 가기",
-                    textStyle = KusTheme.typography.type16m,
-                    containerColor = KusTheme.colors.c_098C62,
-                    roundedCornerShape = RoundedCornerShape(12.dp),
-                    onClick = onLoginButtonClick,
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                )
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(
+                        text = "안내",
+                        style = KusTheme.typography.type16b,
+                        color = KusTheme.colors.c_AAAAAA,
+                    )
 
-                Spacer(Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
 
-                Text(
-                    text = "나중에 하기",
-                    style = KusTheme.typography.type14r,
-                    color = KusTheme.colors.c_AAAAAA,
-                    textDecoration = TextDecoration.Underline,
-                    modifier = Modifier.noRippleClickable(onDismissRequest),
-                )
+                    Text(
+                        text = "현재 서비스는 로그인 후\n이용할 수 있습니다",
+                        style = KusTheme.typography.type16m,
+                        textAlign = TextAlign.Center,
+                    )
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    KusButton(
+                        enabled = true,
+                        buttonName = "로그인 하러 가기",
+                        textStyle = KusTheme.typography.type16m,
+                        containerColor = KusTheme.colors.c_098C62,
+                        roundedCornerShape = RoundedCornerShape(12.dp),
+                        onClick = onLoginButtonClick,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = "나중에 하기",
+                        style = KusTheme.typography.type14r,
+                        color = KusTheme.colors.c_AAAAAA,
+                        textDecoration = TextDecoration.Underline,
+                        modifier = Modifier.noRippleClickable(onDismissRequest),
+                    )
+                }
             }
         }
     }

--- a/shared/data/draw/src/commonMain/kotlin/com/kus/data/draw/di/drawDataModule.kt
+++ b/shared/data/draw/src/commonMain/kotlin/com/kus/data/draw/di/drawDataModule.kt
@@ -7,7 +7,7 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
-val DrawDataModule = module {
+val drawDataModule = module {
     singleOf(::DrawApi)
     singleOf(::DrawRepositoryImpl) bind DrawRepository::class
 }

--- a/shared/domain/auth/src/commonMain/kotlin/com/kus/domain/auth/di/authDomainModule.kt
+++ b/shared/domain/auth/src/commonMain/kotlin/com/kus/domain/auth/di/authDomainModule.kt
@@ -4,6 +4,7 @@ import GetSessionAvailabilityUseCase
 import com.kus.domain.auth.session.SessionEventBus
 import com.kus.domain.auth.session.SessionEventEmitter
 import com.kus.domain.auth.usecase.DeleteUserInfoUseCase
+import com.kus.domain.auth.usecase.DeleteUserTokensUseCase
 import com.kus.domain.auth.usecase.LogoutUseCase
 import com.kus.domain.auth.usecase.PostNaverLoginUseCase
 import org.koin.core.module.dsl.singleOf
@@ -13,6 +14,7 @@ import org.koin.dsl.module
 var authDomainModule = module {
     singleOf(::PostNaverLoginUseCase)
     singleOf(::DeleteUserInfoUseCase)
+    singleOf(::DeleteUserTokensUseCase)
     singleOf(::LogoutUseCase)
     singleOf(::GetSessionAvailabilityUseCase)
     single { SessionEventBus() }

--- a/shared/domain/auth/src/commonMain/kotlin/com/kus/domain/auth/usecase/DeleteUserTokensUseCase.kt
+++ b/shared/domain/auth/src/commonMain/kotlin/com/kus/domain/auth/usecase/DeleteUserTokensUseCase.kt
@@ -1,0 +1,12 @@
+package com.kus.domain.auth.usecase
+
+import com.kus.domain.auth.repository.AuthTokenStore
+
+class DeleteUserTokensUseCase(
+    private val tokenStore: AuthTokenStore,
+) {
+    suspend operator fun invoke(): Boolean {
+        tokenStore.clear()
+        return true
+    }
+}

--- a/shared/domain/my/src/androidMain/kotlin/com/kus/shared/domain/my/Platform.android.kt
+++ b/shared/domain/my/src/androidMain/kotlin/com/kus/shared/domain/my/Platform.android.kt
@@ -1,3 +1,0 @@
-package com.kus.shared.domain.my
-
-actual fun platform() = "Android"

--- a/shared/domain/my/src/commonMain/kotlin/com/kus/shared/domain/my/Platform.kt
+++ b/shared/domain/my/src/commonMain/kotlin/com/kus/shared/domain/my/Platform.kt
@@ -1,3 +1,0 @@
-package com.kus.shared.domain.my
-
-expect fun platform(): String

--- a/shared/domain/my/src/iosMain/kotlin/com/kus/domain/my/Platform.ios.kt
+++ b/shared/domain/my/src/iosMain/kotlin/com/kus/domain/my/Platform.ios.kt
@@ -1,3 +1,0 @@
-package com.kus.domain.my
-
-actual fun platform() = "iOS"

--- a/shared/feature/evaluate/build.gradle.kts
+++ b/shared/feature/evaluate/build.gradle.kts
@@ -77,6 +77,7 @@ kotlin {
 
                 implementation(libs.peekaboo.ui)
                 implementation(libs.peekaboo.image.picker)
+                implementation(libs.bundles.androidxCamera)
             }
         }
 

--- a/shared/feature/login/src/androidMain/kotlin/com/kus/feature/login/navigation/LoginRoute.android.kt
+++ b/shared/feature/login/src/androidMain/kotlin/com/kus/feature/login/navigation/LoginRoute.android.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kus.feature.login.model.SocialAuthResult
 import com.kus.feature.login.ui.LoginPhase
 import com.kus.feature.login.ui.LoginScreen
+import com.kus.feature.login.ui.LoginUiEvent
 import com.kus.feature.login.ui.LoginViewModel
 import com.navercorp.nid.NidOAuth
 import com.navercorp.nid.oauth.util.NidOAuthCallback
@@ -29,6 +30,14 @@ actual fun LoginRoute(
     LaunchedEffect(state.phase) {
         if (state.phase == LoginPhase.Success) {
             navigateToHome()
+        }
+    }
+ 
+    LaunchedEffect(Unit) {
+        viewModel.event.collect { event ->
+            when(event) {
+                LoginUiEvent.NavigateToHome -> navigateToHome()
+            }
         }
     }
 
@@ -74,6 +83,6 @@ actual fun LoginRoute(
             })
         },
         onNavigateToHome = navigateToHome,
-        onSkipLogin = {viewModel.deleteUserTokens()}
+        onSkipLogin = {viewModel.onSkipLoginClick()}
     )
 }

--- a/shared/feature/login/src/androidMain/kotlin/com/kus/feature/login/navigation/LoginRoute.android.kt
+++ b/shared/feature/login/src/androidMain/kotlin/com/kus/feature/login/navigation/LoginRoute.android.kt
@@ -74,6 +74,6 @@ actual fun LoginRoute(
             })
         },
         onNavigateToHome = navigateToHome,
-        onSkipLogin = {viewModel.deleteUserInfo()}
+        onSkipLogin = {viewModel.deleteUserTokens()}
     )
 }

--- a/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginUiEvent.kt
+++ b/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginUiEvent.kt
@@ -1,0 +1,5 @@
+package com.kus.feature.login.ui
+
+sealed class LoginUiEvent {
+    object NavigateToHome : LoginUiEvent()
+}

--- a/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginViewModel.kt
+++ b/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginViewModel.kt
@@ -3,7 +3,7 @@ package com.kus.feature.login.ui
 import UiError
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.kus.domain.auth.usecase.DeleteUserInfoUseCase
+import com.kus.domain.auth.usecase.DeleteUserTokensUseCase
 import com.kus.domain.auth.usecase.PostNaverLoginUseCase
 import com.kus.feature.login.model.SocialAuthResult
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -14,7 +14,7 @@ import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val postNaverLoginUseCase: PostNaverLoginUseCase,
-    private val deleteUserInfoUseCase : DeleteUserInfoUseCase
+    private val deleteUserTokensUseCase : DeleteUserTokensUseCase,
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(
         LoginUiState(
@@ -51,9 +51,9 @@ class LoginViewModel(
         }
     }
 
-    fun deleteUserInfo() {
+    fun deleteUserTokens() {
         viewModelScope.launch {
-            deleteUserInfoUseCase()
+            deleteUserTokensUseCase()
         }
     }
 

--- a/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginViewModel.kt
+++ b/shared/feature/login/src/commonMain/kotlin/com/kus/feature/login/ui/LoginViewModel.kt
@@ -1,12 +1,15 @@
 package com.kus.feature.login.ui
 
 import UiError
+import UiState
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kus.domain.auth.usecase.DeleteUserTokensUseCase
 import com.kus.domain.auth.usecase.PostNaverLoginUseCase
 import com.kus.feature.login.model.SocialAuthResult
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -14,8 +17,10 @@ import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val postNaverLoginUseCase: PostNaverLoginUseCase,
-    private val deleteUserTokensUseCase : DeleteUserTokensUseCase,
+    private val deleteUserTokensUseCase: DeleteUserTokensUseCase,
 ) : ViewModel() {
+    private val _event = MutableSharedFlow<LoginUiEvent>(extraBufferCapacity = 1)
+    val event: SharedFlow<LoginUiEvent> = _event
     private val _uiState = MutableStateFlow(
         LoginUiState(
             authState = UiState.Idle
@@ -38,7 +43,7 @@ class LoginViewModel(
     }
 
     fun onNaverAuthFail(auth: SocialAuthResult) {
-        if(auth !is SocialAuthResult.Failure) return
+        if (auth !is SocialAuthResult.Failure) return
 
         _uiState.update {
             it.copy(
@@ -51,9 +56,10 @@ class LoginViewModel(
         }
     }
 
-    fun deleteUserTokens() {
+    fun onSkipLoginClick() {
         viewModelScope.launch {
             deleteUserTokensUseCase()
+            _event.emit(LoginUiEvent.NavigateToHome)
         }
     }
 

--- a/shared/feature/login/src/iosMain/kotlin/com/kus/feature/login/navigation/LoginRoute.ios.kt
+++ b/shared/feature/login/src/iosMain/kotlin/com/kus/feature/login/navigation/LoginRoute.ios.kt
@@ -10,6 +10,7 @@ import com.kus.feature.login.model.NaverAuthResult
 import com.kus.feature.login.model.SocialAuthResult
 import com.kus.feature.login.ui.LoginPhase
 import com.kus.feature.login.ui.LoginScreen
+import com.kus.feature.login.ui.LoginUiEvent
 import com.kus.feature.login.ui.LoginViewModel
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -26,6 +27,14 @@ actual fun LoginRoute(
     LaunchedEffect(state.phase) {
         if (state.phase == LoginPhase.Success) {
             navigateToHome()
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.event.collect { event ->
+            when(event) {
+                LoginUiEvent.NavigateToHome -> navigateToHome()
+            }
         }
     }
 
@@ -57,6 +66,6 @@ actual fun LoginRoute(
             }
         },
         onNavigateToHome = navigateToHome,
-        onSkipLogin = { viewModel.deleteUserTokens() }
+        onSkipLogin = { viewModel.onSkipLoginClick() }
     )
 }

--- a/shared/feature/login/src/iosMain/kotlin/com/kus/feature/login/navigation/LoginRoute.ios.kt
+++ b/shared/feature/login/src/iosMain/kotlin/com/kus/feature/login/navigation/LoginRoute.ios.kt
@@ -57,6 +57,6 @@ actual fun LoginRoute(
             }
         },
         onNavigateToHome = navigateToHome,
-        onSkipLogin = { viewModel.deleteUserInfo() }
+        onSkipLogin = { viewModel.deleteUserTokens() }
     )
 }

--- a/shared/feature/my/src/commonMain/kotlin/com/kus/feature/my/ui/MyScreen.kt
+++ b/shared/feature/my/src/commonMain/kotlin/com/kus/feature/my/ui/MyScreen.kt
@@ -55,6 +55,10 @@ fun MyScreen(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     LaunchedEffect(Unit) {
+        viewModel.requireLogin()
+    }
+
+    LaunchedEffect(Unit) {
         viewModel.navigationEvent.collect { event ->
             when (event) {
                 is MyNavigationEvent.NavigateToLogin -> onLoginNavigate()

--- a/shared/feature/my/src/commonMain/kotlin/com/kus/feature/my/ui/MyViewModel.kt
+++ b/shared/feature/my/src/commonMain/kotlin/com/kus/feature/my/ui/MyViewModel.kt
@@ -31,10 +31,6 @@ class MyViewModel(
     private val _navigationEvent = MutableSharedFlow<MyNavigationEvent>()
     val navigationEvent = _navigationEvent.asSharedFlow()
 
-    init {
-        requireLogin()
-    }
-
     fun requireLogin() = viewModelScope.launch {
         if (!getSessionAvailabilityUseCase()) {
             sessionEvents.emit(SessionEvent.LoginRequired)


### PR DESCRIPTION
## 개요
#41 
<br/>

## PR 유형
해당하는 항목에 체크해주세요.

- [ ] Add — 리소스/코드/컴포넌트 추가 (기능 변화 없음)
- [ ] Feat — 사용자에게 보이는 새로운 기능 추가
- [X] Fix — 버그 수정
- [ ] Refactor — 기능 변경 없는 코드 구조 개선
- [ ] Docs / Comment — 문서, 주석 수정
- [ ] Test — 테스트 추가 또는 리팩토링
- [ ] Build / Config — 빌드, 의존성, 설정 변경
- [ ] File — 파일 / 폴더 구조 변경

<br/>

## 변경 사항
<!-- 어떤 변경을 했는지 간단히 작성해주세요 -->

- 건너뛰기 UseCase 수정
- 파키부 라이브러리 관련 16kb 페이지 대응
- 마이 뷰모델에서 init 블럭으로 로그인 확인하는 로직을 뷰로 이동

<br/>

## 📸 화면 / 영상 (선택)
<!-- 변경된 UI나 동작을 보여주세요 --> 

### Before
<!-- 이전 화면 -->

### After
<!-- 변경된 화면 -->

<br/> 

## 리뷰어에게 전달할 사항
- 의존성을 확인해보니 io.github.onseok:peekaboo-ui:0.5.2가 CameraX 1.3.2을 가져오고 libimage_processing_util_jni.so가 16KB page size 비호환으로 잡혀서 이를 16KB 페이지로 대응가능한 라이브러리로 추가하였습니다.
- navigation 구조가 변경되면서 마이 뷰모델에서 init 블럭에서 로그인이 되어있는지 확인하면 의도한 대로 동작하지 않습니다. 따라서 Myscreen에서 LaunchedEffect를 사용하여 My 탭에 들어올 때마다 다이얼로그가 나오도록 하였습니다.
- 마지막으로 기존에는 오버레이 방식으로 다이얼로그를 보여줬는데 이를 다이얼로그로 수정하였습니다. 어제 회의했던 바텀바와 시스템바 모두 클릭 가능한 영역으로 만들었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카메라 기능 지원 추가

* **개선 사항**
  * 로그인 안내 UI가 오버레이에서 모달 대화상자로 개선되어 닫기 동작이 더 자연스러워짐
  * 로그인 건너뛰기 시 사용자 토큰이 정확히 삭제되도록 변경
  * 로그인 흐름이 이벤트 기반으로 업데이트되어, 로그인 후 또는 건너뛰기 시 홈으로 자동 이동함
  * 마이페이지 진입 시 자동 로그인 확인을 실행하도록 변경
<!-- end of auto-generated comment: release notes by coderabbit.ai -->