### PR TITLE
[Fix/#49] iOS 커뮤니티 탭 상세 게시글 본문 하단 여백 제거

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ multiplatform-settings = "1.1.1"
 kotlinx-io = "0.8.2"
 compottie = "2.0.2"
 cameraX = "1.5.3"
+androidx-webkit = "1.9.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -115,6 +116,7 @@ compose-ui-graphics = { module = "org.jetbrains.compose.ui:ui-graphics", version
 multiplatform-settings = { group = "com.russhwolf", name = "multiplatform-settings", version.ref = "multiplatform-settings" }
 compottie-core = { module = "io.github.alexzhirkevich:compottie", version.ref = "compottie" }
 
+androidx-webkit = { module = "androidx.webkit:webkit", version.ref = "androidx-webkit" }
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }

--- a/iosApp/Configuration/Config.xcconfig
+++ b/iosApp/Configuration/Config.xcconfig
@@ -1,9 +1,7 @@
 #include "Secrets.xcconfig"
 
-TEAM_ID=
-
 PRODUCT_NAME=Kustaurant
-PRODUCT_BUNDLE_IDENTIFIER=com.kus.kustaurant.Kustaurant$(TEAM_ID)
+PRODUCT_BUNDLE_IDENTIFIER=kustaurant.Kustaurant
 
 CURRENT_PROJECT_VERSION=1
 MARKETING_VERSION=1.0

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -14,7 +14,5 @@
 	<string>$(NAVER_MAP_CLIENT_ID)</string>
 	<key>PRODUCT_NAME</key>
 	<string>$(PRODUCT_NAME)</string>
-	<key>CFBundleDisplayName</key>
-	<string>${CFBundleDisplayName}</string>
 </dict>
 </plist>

--- a/shared/feature/community/build.gradle.kts
+++ b/shared/feature/community/build.gradle.kts
@@ -65,6 +65,7 @@ kotlin {
                 implementation(libs.naver.maps)
                 implementation(libs.androidx.activity.compose)
                 implementation(libs.koin.android)
+                implementation(libs.androidx.webkit)
             }
         }
 

--- a/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
+++ b/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
@@ -1,15 +1,19 @@
 package com.kus.feature.community.ui.detail
 
 import android.annotation.SuppressLint
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.kus.designsystem.theme.KusTheme
+import androidx.webkit.WebViewAssetLoader
+import androidx.webkit.WebViewClientCompat
+import org.json.JSONObject
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -19,38 +23,71 @@ actual fun HtmlBodyView(
 ) {
     val context = LocalContext.current
 
-    val styledHtml =
+    val assetLoader = remember {
+        WebViewAssetLoader.Builder()
+            .addPathHandler(
+                "/assets/",
+                WebViewAssetLoader.AssetsPathHandler(context)
+            )
+            .build()
+    }
+
+    val customWebViewClient = remember {
+        object : WebViewClientCompat() {
+            override fun shouldInterceptRequest(
+                view: WebView?,
+                request: WebResourceRequest
+            ): WebResourceResponse? {
+                return assetLoader.shouldInterceptRequest(request.url)
+            }
+        }
+    }
+
+    val escapedHtml = remember(html) {
+        JSONObject.quote(html)
+    }
+
+    val wrappedHtml = remember(html) {
         """
+        <!DOCTYPE html>
         <html>
         <head>
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <style>
-            html, body {
-                margin: 0;
-                padding: 0;
-                background-color: transparent;
-            }
-        </style>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                html, body {
+                    margin: 0;
+                    padding: 0;
+                    background-color: transparent;
+                }
+            </style>
+           <script src="https://appassets.androidplatform.net/assets/composeResources/kustaurant.shared.feature.community.generated.resources/files/editor/purify.min.js"></script>
         </head>
         <body>
-        $html
+            <div id="content"></div>
+
+            <script>
+                const dirtyHtml = $escapedHtml;
+                const cleanHtml = DOMPurify.sanitize(dirtyHtml);
+                document.getElementById("content").innerHTML = cleanHtml;
+            </script>
         </body>
         </html>
         """.trimIndent()
+    }
 
     AndroidView(
-        modifier = modifier
-            .padding(top = 0.dp),
+        modifier = modifier.padding(top = 0.dp),
         factory = {
             WebView(context).apply {
                 settings.javaScriptEnabled = true
                 setBackgroundColor(android.graphics.Color.TRANSPARENT)
+                webViewClient = customWebViewClient
             }
         },
         update = { webView ->
             webView.loadDataWithBaseURL(
-                null,
-                styledHtml,
+                "https://appassets.androidplatform.net/",
+                wrappedHtml,
                 "text/html",
                 "utf-8",
                 null

--- a/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
+++ b/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
@@ -40,8 +40,7 @@ actual fun HtmlBodyView(
 
     AndroidView(
         modifier = modifier
-            .padding(top = 0.dp)
-            .border(1.dp, KusTheme.colors.c_43AB38),
+            .padding(top = 0.dp),
         factory = {
             WebView(context).apply {
                 settings.javaScriptEnabled = true

--- a/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
+++ b/shared/feature/community/src/androidMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.android.kt
@@ -2,10 +2,14 @@ package com.kus.feature.community.ui.detail
 
 import android.annotation.SuppressLint
 import android.webkit.WebView
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.kus.designsystem.theme.KusTheme
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -15,8 +19,29 @@ actual fun HtmlBodyView(
 ) {
     val context = LocalContext.current
 
+    val styledHtml =
+        """
+        <html>
+        <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <style>
+            html, body {
+                margin: 0;
+                padding: 0;
+                background-color: transparent;
+            }
+        </style>
+        </head>
+        <body>
+        $html
+        </body>
+        </html>
+        """.trimIndent()
+
     AndroidView(
-        modifier = modifier,
+        modifier = modifier
+            .padding(top = 0.dp)
+            .border(1.dp, KusTheme.colors.c_43AB38),
         factory = {
             WebView(context).apply {
                 settings.javaScriptEnabled = true
@@ -26,7 +51,7 @@ actual fun HtmlBodyView(
         update = { webView ->
             webView.loadDataWithBaseURL(
                 null,
-                html,
+                styledHtml,
                 "text/html",
                 "utf-8",
                 null

--- a/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/ui/detail/CommunityDetailSuccessContent.kt
+++ b/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/ui/detail/CommunityDetailSuccessContent.kt
@@ -146,7 +146,7 @@ private fun DetailAuthorHeader(post: CommunityPostUi) {
         Spacer(Modifier.width(2.dp))
 
         Text(
-            text = post.timeAgo ?: "",
+            text = post.timeAgo,
             style = KusTheme.typography.type12r,
             color = KusTheme.colors.c_666666
         )

--- a/shared/feature/community/src/iosMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.ios.kt
+++ b/shared/feature/community/src/iosMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.ios.kt
@@ -12,12 +12,22 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.UIKitView
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSBundle
 import platform.UIKit.UIColor
 import platform.UIKit.UIUserInterfaceStyle
 import platform.WebKit.WKNavigation
 import platform.WebKit.WKNavigationDelegateProtocol
 import platform.WebKit.WKWebView
 import platform.darwin.NSObject
+
+private fun String.escapeForJsSingleQuote(): String {
+    return this
+        .replace("\\", "\\\\")
+        .replace("'", "\\'")
+        .replace("\n", "\\n")
+        .replace("\r", "")
+        .replace("</script>", "<\\/script>")
+}
 
 @OptIn(ExperimentalForeignApi::class)
 @Composable
@@ -28,26 +38,39 @@ actual fun HtmlBodyView(
     var webViewHeight by remember { mutableStateOf(1) }
 
     val styledHtml = remember(html) {
+        val escapedHtml = html.escapeForJsSingleQuote()
+
         """
-    <html>
-    <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <style>
-        * { box-sizing: border-box; }
-        html { background-color: #ffffff !important; }
-        body { 
-            margin: 0; 
-            padding: 0; 
-            font-size: 16px; 
-            color: #000000 !important;
-            background-color: #ffffff !important;
-            -webkit-text-fill-color: #000000 !important;
-        }
-    </style>
-    </head>
-    <body>$html</body>
-    </html>
-    """.trimIndent()
+        <html>
+        <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <style>
+                * { box-sizing: border-box; }
+                html { background-color: #ffffff !important; }
+                body {
+                    margin: 0;
+                    padding: 0;
+                    font-size: 16px;
+                    color: #000000 !important;
+                    background-color: #ffffff !important;
+                    -webkit-text-fill-color: #000000 !important;
+                    overflow: hidden;
+                }
+            </style>
+
+            <script src="editor/purify.min.js"></script>
+        </head>
+        <body>
+            <div id="content"></div>
+
+            <script>
+                const rawHtml = '$escapedHtml';
+                const cleanHtml = DOMPurify.sanitize(rawHtml);
+                document.getElementById('content').innerHTML = cleanHtml;
+            </script>
+        </body>
+        </html>
+        """.trimIndent()
     }
 
     val delegate = remember {
@@ -71,18 +94,20 @@ actual fun HtmlBodyView(
             .fillMaxWidth()
             .height(webViewHeight.dp),
         factory = {
-            val webView = WKWebView(frame = CGRectMake(0.0, 0.0, 300.0, 300.0))
-            webView.navigationDelegate = delegate
-            webView.opaque = true
-            webView.backgroundColor = UIColor.whiteColor
-            webView.scrollView.backgroundColor = UIColor.whiteColor
-            webView.scrollView.scrollEnabled = false
-            webView.overrideUserInterfaceStyle = UIUserInterfaceStyle.UIUserInterfaceStyleLight
-
-            webView
+            WKWebView(frame = CGRectMake(0.0, 0.0, 300.0, 300.0)).apply {
+                navigationDelegate = delegate
+                opaque = true
+                backgroundColor = UIColor.whiteColor
+                scrollView.backgroundColor = UIColor.whiteColor
+                scrollView.scrollEnabled = false
+                overrideUserInterfaceStyle = UIUserInterfaceStyle.UIUserInterfaceStyleLight
+            }
         },
         update = { webView ->
-            webView.loadHTMLString(styledHtml, baseURL = null)
+            webView.loadHTMLString(
+                styledHtml,
+                baseURL = NSBundle.mainBundle.bundleURL
+            )
         }
     )
 }

--- a/shared/feature/community/src/iosMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.ios.kt
+++ b/shared/feature/community/src/iosMain/kotlin/com/kus/feature/community/ui/detail/HtmlBodyView.ios.kt
@@ -9,14 +9,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import platform.UIKit.UIColor
-import platform.WebKit.WKWebView
 import androidx.compose.ui.viewinterop.UIKitView
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.CoreGraphics.CGRectMake
+import platform.UIKit.UIColor
 import platform.UIKit.UIUserInterfaceStyle
 import platform.WebKit.WKNavigation
 import platform.WebKit.WKNavigationDelegateProtocol
+import platform.WebKit.WKWebView
 import platform.darwin.NSObject
 
 @OptIn(ExperimentalForeignApi::class)
@@ -25,7 +25,7 @@ actual fun HtmlBodyView(
     html: String,
     modifier: Modifier
 ) {
-    var webViewHeight by remember { mutableStateOf(300) }
+    var webViewHeight by remember { mutableStateOf(1) }
 
     val styledHtml = remember(html) {
         """
@@ -77,7 +77,6 @@ actual fun HtmlBodyView(
             webView.backgroundColor = UIColor.whiteColor
             webView.scrollView.backgroundColor = UIColor.whiteColor
             webView.scrollView.scrollEnabled = false
-
             webView.overrideUserInterfaceStyle = UIUserInterfaceStyle.UIUserInterfaceStyleLight
 
             webView


### PR DESCRIPTION
## 개요
#47 

<br/>

## PR 유형
해당하는 항목에 체크해주세요.

- [ ] Add — 리소스/코드/컴포넌트 추가 (기능 변화 없음)
- [ ] Feat — 사용자에게 보이는 새로운 기능 추가
- [X] Fix — 버그 수정
- [ ] Refactor — 기능 변경 없는 코드 구조 개선
- [ ] Docs / Comment — 문서, 주석 수정
- [ ] Test — 테스트 추가 또는 리팩토링
- [ ] Build / Config — 빌드, 의존성, 설정 변경
- [ ] File — 파일 / 폴더 구조 변경

<br/>

## 변경 사항
<!-- 어떤 변경을 했는지 간단히 작성해주세요 -->

- iOS 커뮤니티 탭 상세 게시글 본문 하단 여백 제거
- iOS identifier 수정

<br/>

## 📸 화면 / 영상 (선택)
<!-- 변경된 UI나 동작을 보여주세요 --> 

### Before
<!-- 이전 화면 -->

### After
<!-- 변경된 화면 -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/66deb34b-ac47-4a8d-a918-cec26dd3c5eb" />

<br/> 
 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * HTML 렌더링 안정화: 뷰포트·기본 스타일 적용 및 DOMPurify를 통한 안전한 HTML 삽입으로 렌더링 신뢰성 향상
  * 커뮤니티 상세 페이지의 시간 표시가 직접적으로 반영되도록 수정

* **신규 기능**
  * Android WebView에서 로컬 자산 접근 지원 및 외부 스크립트 기반 정화 적용
  * Android용 WebKit 라이브러리 추가

* **설정 변경**
  * iOS 번들 식별자 고정화 및 앱 표시 이름 설정 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->