### PR TITLE
[Chore/#51] 사용하지 않는 아이콘 제거(티어, 커뮤니티, 뽑기 탭)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/kus/kustaurant/navigation/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/kus/kustaurant/navigation/MainScreen.kt
@@ -40,14 +40,14 @@ import com.kus.feature.login.navigation.Login
 import com.kus.feature.my.navigation.My
 import com.kus.feature.my.navigation.myMainNavGraph
 import com.kus.feature.my.navigation.navigateToCheckedRest
-import com.kus.feature.my.navigation.navigateToFeedback
+import com.kus.feature.my.navigation.navigateToEditProfile
 import com.kus.feature.my.navigation.navigateToFavoriteRest
+import com.kus.feature.my.navigation.navigateToFeedback
 import com.kus.feature.my.navigation.navigateToMyArticle
 import com.kus.feature.my.navigation.navigateToMyComment
 import com.kus.feature.my.navigation.navigateToMyWebView
 import com.kus.feature.my.navigation.navigateToScrap
 import com.kus.feature.search.navigation.Search
-import com.kus.feature.tier.TierKeys as TierResultKeys
 import com.kus.feature.tier.config.TierKeys.TIER_INITIAL_JSON
 import com.kus.feature.tier.config.TierKeys.TIER_RESULT_JSON
 import com.kus.feature.tier.navigation.Tier
@@ -55,6 +55,7 @@ import com.kus.feature.tier.navigation.TierCategorySelect
 import com.kus.feature.tier.navigation.tierMainNavGraph
 import com.kus.feature.tier.ui.TierFilterState
 import com.kus.shared.domain.model.tier.filter.Cuisine
+import com.kus.feature.tier.TierKeys as TierResultKeys
 
 @Composable
 fun MainScreen(
@@ -233,6 +234,9 @@ fun MainScreen(
 
             myMainNavGraph(
                 onShowMessage = onShowMessage,
+                navigateToEditProfile = { nickName, email, phoneNumber ->
+                    rootNavController.navigateToEditProfile(nickName, email, phoneNumber)
+                },
                 navigateToNotice = {
                     rootNavController.navigateToMyWebView(
                         title = "공지사항",

--- a/composeApp/src/commonMain/kotlin/com/kus/kustaurant/navigation/MainScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/kus/kustaurant/navigation/MainScreen.kt
@@ -194,8 +194,6 @@ fun MainScreen(
             )
 
             drawNavGraph(
-                onSearchClick = { rootNavController.navigate(Search) },
-                onAlarmClick = {},
                 onShowMessage = onShowMessage,
                 navigateToDrawResult = { route -> mainNavController.navigate(route) },
                 onBackClick = { mainNavController.popBackStack() },
@@ -231,7 +229,6 @@ fun MainScreen(
                 onPostWriteClick = {
                     rootNavController.navigate(CommunityWrite)
                 },
-                onSearchClick = { },
             )
 
             myMainNavGraph(

--- a/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/navigation/CommunityNavGraph.kt
+++ b/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/navigation/CommunityNavGraph.kt
@@ -50,7 +50,6 @@ fun NavGraphBuilder.communityMainNavGraph(
     onBackButtonClick: () -> Unit,
     onPostClick: (Long) -> Unit,
     onPostWriteClick: () -> Unit,
-    onSearchClick: () -> Unit,
 ) {
     composable<Community> { backStackEntry ->
         val viewModel: CommunityViewModel = koinViewModel()
@@ -93,7 +92,6 @@ fun NavGraphBuilder.communityMainNavGraph(
             onPostClick = onPostClick,
             onWriteClick = onPostWriteClick,
             onBackClick = onBackButtonClick,
-            onSearchClick = onSearchClick,
             onShowMessage = onShowMessage,
         )
     }

--- a/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/ui/CommunityScreen.kt
+++ b/shared/feature/community/src/commonMain/kotlin/com/kus/feature/community/ui/CommunityScreen.kt
@@ -39,13 +39,8 @@ import com.kus.feature.community.ui.floatingButton.WriteFab
 import com.kus.feature.community.ui.list.CommunityListContent
 import com.kus.feature.community.ui.ranking.RankingContent
 import kotlinx.coroutines.launch
-import kustaurant.shared.core.designsystem.generated.resources.ic_alarm_off
-import kustaurant.shared.core.designsystem.generated.resources.ic_arrow_back
-import kustaurant.shared.core.designsystem.generated.resources.ic_search
-import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
 import rememberFabVisibleOnScrollUp
-import kustaurant.shared.core.designsystem.generated.resources.Res as CoreRes
 
 @Composable
 fun CommunityScreen(
@@ -88,12 +83,6 @@ fun CommunityScreen(
                         .fillMaxWidth()
                         .height(64.dp)
                         .padding(horizontal = 8.dp),
-                    leftIcon = painterResource(CoreRes.drawable.ic_arrow_back),
-                    rightFirstIcon = painterResource(CoreRes.drawable.ic_search),
-                    rightSecondIcon = painterResource(CoreRes.drawable.ic_alarm_off),
-                    onLeftClicked = onBackClick,
-                    onRightFirstClicked = onSearchClick,
-                    onRightSecondClicked = onAlarmClick,
                 ) {
                     Text(
                         text = "커뮤니티",

--- a/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/navigation/DrawNavGraph.kt
+++ b/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/navigation/DrawNavGraph.kt
@@ -19,16 +19,12 @@ data class DrawResult(
 )
 
 fun NavGraphBuilder.drawNavGraph(
-    onSearchClick: () -> Unit,
-    onAlarmClick: () -> Unit,
     onShowMessage: (String) -> Unit,
     navigateToDrawResult: (DrawResult) -> Unit,
     onBackClick: () -> Unit,
 ) {
     composable<Draw> {
         DrawSelectScreen(
-            onSearchClick = onSearchClick,
-            onAlarmClick = onAlarmClick,
             onBackClick = onBackClick,
             onApplyClick = { locations, cuisines ->
                 val payload = DrawResultPayload(

--- a/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/ui/result/DrawResultScreen.kt
+++ b/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/ui/result/DrawResultScreen.kt
@@ -62,9 +62,7 @@ import io.kamel.image.KamelImage
 import io.kamel.image.asyncPainterResource
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
-import kustaurant.shared.core.designsystem.generated.resources.ic_alarm_off
 import kustaurant.shared.core.designsystem.generated.resources.ic_arrow_back
-import kustaurant.shared.core.designsystem.generated.resources.ic_search
 import kustaurant.shared.feature.draw.generated.resources.Res
 import kustaurant.shared.feature.draw.generated.resources.ic_retry
 import org.jetbrains.compose.resources.painterResource
@@ -115,11 +113,7 @@ fun DrawResultScreen(
                     .height(64.dp)
                     .padding(horizontal = 8.dp),
                 leftIcon = painterResource(CoreRes.drawable.ic_arrow_back),
-                rightFirstIcon = painterResource(CoreRes.drawable.ic_search),
-                rightSecondIcon = painterResource(CoreRes.drawable.ic_alarm_off),
                 onLeftClicked = onBackClick,
-                onRightFirstClicked = {},
-                onRightSecondClicked = {},
             ) {
                 Text(
                     text = "랜덤 맛집 뽑기",

--- a/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/ui/select/DrawSelectScreen.kt
+++ b/shared/feature/draw/src/commonMain/kotlin/com/kus/feature/draw/ui/select/DrawSelectScreen.kt
@@ -35,20 +35,12 @@ import com.kus.designsystem.theme.KusTheme
 import com.kus.feature.draw.mapper.toImage
 import com.kus.shared.domain.model.tier.filter.Cuisine
 import com.kus.shared.domain.model.tier.filter.Location
-import kustaurant.shared.core.designsystem.generated.resources.ic_alarm_off
-import kustaurant.shared.core.designsystem.generated.resources.ic_arrow_back
-import kustaurant.shared.core.designsystem.generated.resources.ic_search
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.viewmodel.koinViewModel
-import kotlin.collections.chunked
-import kotlin.collections.forEach
-import kustaurant.shared.core.designsystem.generated.resources.Res as CoreRes
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun DrawSelectScreen(
-    onSearchClick: () -> Unit,
-    onAlarmClick: () -> Unit,
     onApplyClick: (Set<Location>, Set<Cuisine>) -> Unit,
     onBackClick: () -> Unit,
     viewModel: DrawSelectViewModel = koinViewModel(),
@@ -68,11 +60,6 @@ fun DrawSelectScreen(
                         .fillMaxWidth()
                         .height(64.dp)
                         .padding(horizontal = 8.dp),
-                    leftIcon = painterResource(CoreRes.drawable.ic_arrow_back),
-                    rightFirstIcon = painterResource(CoreRes.drawable.ic_search),
-                    rightSecondIcon = painterResource(CoreRes.drawable.ic_alarm_off),
-                    onRightFirstClicked = onSearchClick,
-                    onRightSecondClicked = onAlarmClick,
                 ) {
                     Text(
                         text = "랜덤 맛집 뽑기",

--- a/shared/feature/tier/src/commonMain/kotlin/com/kus/feature/tier/ui/TierScreen.kt
+++ b/shared/feature/tier/src/commonMain/kotlin/com/kus/feature/tier/ui/TierScreen.kt
@@ -49,9 +49,6 @@ import com.kus.designsystem.util.noRippleClickable
 import com.kus.feature.tier.ui.list.TierListScreen
 import com.kus.feature.tier.ui.map.TierMapPlatform
 import kotlinx.coroutines.launch
-import kustaurant.shared.core.designsystem.generated.resources.ic_alarm_off
-import kustaurant.shared.core.designsystem.generated.resources.ic_arrow_back
-import kustaurant.shared.core.designsystem.generated.resources.ic_search
 import kustaurant.shared.feature.tier.generated.resources.Res
 import kustaurant.shared.feature.tier.generated.resources.ic_ai_filter_off
 import kustaurant.shared.feature.tier.generated.resources.ic_ai_filter_on
@@ -59,14 +56,10 @@ import kustaurant.shared.feature.tier.generated.resources.ic_filter
 import org.jetbrains.compose.resources.painterResource
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
-import kustaurant.shared.core.designsystem.generated.resources.Res as CoreRes
 
 @Composable
 fun TierScreen(
     modifier: Modifier = Modifier,
-    onBackClick: () -> Unit = {},
-    onSearchClick: () -> Unit = {},
-    onAlarmClick: () -> Unit = {},
     onFilterClick: () -> Unit = {},
     onShowMessage: (String) -> Unit,
     onNavigateRestaurantDetail: (Long) -> Unit = {},
@@ -102,12 +95,6 @@ fun TierScreen(
                 .fillMaxWidth()
                 .height(56.dp)
                 .padding(horizontal = 8.dp),
-            leftIcon = painterResource(CoreRes.drawable.ic_arrow_back),
-            rightFirstIcon = painterResource(CoreRes.drawable.ic_search),
-            rightSecondIcon = painterResource(CoreRes.drawable.ic_alarm_off),
-            onLeftClicked = onBackClick,
-            onRightFirstClicked = onSearchClick,
-            onRightSecondClicked = onAlarmClick,
         ) {
             TierCenterTabs(
                 selectedIndex = pagerState.currentPage,


### PR DESCRIPTION
## 개요
#51
<br/>

## PR 유형
해당하는 항목에 체크해주세요.

- [X] Add — 리소스/코드/컴포넌트 추가 (기능 변화 없음)
- [ ] Feat — 사용자에게 보이는 새로운 기능 추가
- [ ] Fix — 버그 수정
- [ ] Refactor — 기능 변경 없는 코드 구조 개선
- [ ] Docs / Comment — 문서, 주석 수정
- [ ] Test — 테스트 추가 또는 리팩토링
- [ ] Build / Config — 빌드, 의존성, 설정 변경
- [ ] File — 파일 / 폴더 구조 변경

<br/>

## 변경 사항
<!-- 어떤 변경을 했는지 간단히 작성해주세요 -->

- 티어탭, 뽑기 탭, 커뮤니티 탭 에서 뒤로가기 와 알림, 검색 아이콘을 제거했습니다.

<br/>

## 📸 화면 / 영상 (선택)
<!-- 변경된 UI나 동작을 보여주세요 --> 

### Before
<!-- 이전 화면 -->

### After
<!-- 변경된 화면 -->

<br/> 

## 리뷰어에게 전달할 사항
<!-- 리뷰 시 참고해 주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 여러 화면에서 검색 및 알림 버튼의 클릭 핸들러가 제거되어 관련 상호작용이 단순화되었습니다.
  * 각 화면의 상단 바에서 오른쪽 아이콘(검색/알림)이 제거되어 UI가 정리되었습니다.
  * 더 이상 사용되지 않는 파라미터와 리소스 임포트가 삭제되어 네비게이션/화면 연동이 간결해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->